### PR TITLE
Admin UI fix proxy to api-docs and use ../.env

### DIFF
--- a/policy-truth-backend/admin/src/App.vue
+++ b/policy-truth-backend/admin/src/App.vue
@@ -82,7 +82,7 @@
             <cv-side-nav-link href="javascript:void(0)">
               L1 link
             </cv-side-nav-link>
-            <cv-side-nav-link href="http://localhost:5000/api-docs/">
+            <cv-side-nav-link href="/api-docs/">
               API Docs
             </cv-side-nav-link>
 

--- a/policy-truth-backend/admin/vue.config.js
+++ b/policy-truth-backend/admin/vue.config.js
@@ -1,8 +1,13 @@
+require('dotenv').config({path: '../.env'});
+
+const port = process.env.PORT || 5000;
+const target = `http://localhost:${port}/`;
+
 module.exports = {
   devServer: {
     proxy: {
       '^/api': {
-        target: 'http://localhost:5000/',
+        target,
         ws: true,
         changeOrigin: true
       }


### PR DESCRIPTION
* api-docs in admin UI was using wrong URL
* Also fixed to use .env PORT so a Dev wouldn't have to edit code to connect to the parent server.