### PR TITLE
process.env.VUE_APP_MOCK_DATA to run the client with mock data

### DIFF
--- a/client/src/data/PolicyDataList.js
+++ b/client/src/data/PolicyDataList.js
@@ -364,7 +364,8 @@ const policyDataList = [
 export default {
   fetchPolicyDataList: (vuestore) => {
     // Use the above mock data when env var MOCK is true
-    if (process.env.USE_MOCK_DATA) {
+    if (process.env.VUE_APP_MOCK_DATA) {
+      console.log('Using MOCK DATA for policy list');
       vuestore.dispatch("policyliststore/updateItems", {
         items: policyDataList,
       });

--- a/client/src/data/PolicyDetails.js
+++ b/client/src/data/PolicyDetails.js
@@ -105,7 +105,8 @@ export default {
   //
   // fetchPolicyDetails: (policyid, vuestore) => {
   //
-  //   if (process.env.MOCK) {
+  //   if (process.env.VUE_APP_MOCK_DATA) {
+  //     console.log('Using MOCK DATA in PolicyDetails.js');
   //     console.log(`Policy details store: ${policyid}`);
   //     policyDetails.id = policyid;
   //     vuestore.dispatch("policyliststore/updateItemDetails", {

--- a/client/src/store/modules/policystore.js
+++ b/client/src/store/modules/policystore.js
@@ -16,7 +16,8 @@ export default {
 
                 if (payload != null && typeof payload !== "undefined") {
                     console.log('Fetching:', payload);
-                  if (process.env.USE_MOCK_DATA) {
+                  if (process.env.VUE_APP_MOCK_DATA) {
+                    console.log('Using MOCK DATA for policy store');
                     commit('setPolicy', policy);
                   } else {
                     fetch(`/api/v1/legislativeArtifacts/fullDetail/${payload}`)


### PR DESCRIPTION
* Use process.env.VUE_APP_MOCK_DATA to enable the old mock data code.
* Set it in client/.env. When this is set the SERVER_URL won't matter.
* Renamed it with VUE_APP_* prefix so Vue.js code will see it.