### PR TITLE
use a more open-source-project friendly conttributor list

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,29 +5,7 @@
 
 # Team Truth
 
-The initial version was developed by members of IBM in the summer of 2020.
-
-## Team Members
-
-- Aakansha Agrawal - IBM
-- Khadija Al-Selini - IBM
-- Parisa Babaali - IBM
-- Boz Bosma - IBM
-- Kimberly Cassidy - IBM
-- Stephanie Daher - IBM
-- Michelle Esselen - IBM
-- Peter Ihlenfeldt - IBM
-- Abiola Jones - IBM
-- Rahul Kalluri - IBM
-- Joe Konathapally - IBM
-- Frank Madden - IBM
-- Henry Nash - IBM
-- Sharon Osahon - IBM
-- Colby Stone - IBM
-- Mark Sturdevant - IBM
-- Tanushree Paul - IBM
-- Bimsara Pilapitiya - IBM
-- Ya Jiao Zheng - IBM
+The initial version was developed by contrinutors at IBM in the summer of 2020, namely: Aakansha Agrawal, Khadija Al-Selini, Parisa Babaali, Boz Bosma, Kimberly Cassidy, Stephanie Daher, Michelle Esselen, Peter Ihlenfeldt, Abiola Jones, Rahul Kalluri, Joe Konathapally, Frank Madden, Henry Nash, Sharon Osahon, Colby Stone, Mark Sturdevant, Tanushree Paul, Bimsara Pilapitiya, Ya Jiao Zheng
 
 ## Contents
 


### PR DESCRIPTION
Listing everyone with IBM stamped next to them (and only IBM) will look off putting to the non-IBMers that we want to attract to contribute. That was explicitly why this was formatted as it was, before this was changed by an earlier PR :-)