### PR TITLE
testfix Removing timezone from date_introduced in getIntroDt test to …

### DIFF
--- a/client/tests/unit/components/Policy.spec.js
+++ b/client/tests/unit/components/Policy.spec.js
@@ -14,7 +14,7 @@ describe('Policy tests', () => {
       expect(wrapper.find('.summary').text()).toEqual('Policy Summary');
     });
     it('should display appropriate Intro Date', () => {
-      const wrapper = factory({ propsData: { date_introduced: '2020-06-01T05:00:00.000Z' } });
+      const wrapper = factory({ propsData: { date_introduced: '2020-06-01T01:00:00.000' } });
       expect(wrapper.find('.introdate').text()).toEqual('Introduced: 6-1-2020');
     });
   });

--- a/client/tests/unit/components/Policy.spec.js
+++ b/client/tests/unit/components/Policy.spec.js
@@ -36,7 +36,7 @@ describe('Policy tests', () => {
     });
     describe('getIntroDt tests', () => {
       it('should return formatted date', () => {
-        const wrapper = factory({ propsData: { date_introduced: '2020-06-01T05:00:00.000Z' } });
+        const wrapper = factory({ propsData: { date_introduced: '2020-06-01T01:00:00.000' } });
         expect(wrapper.vm.getIntroDt).toEqual('6-1-2020');
       });
     });


### PR DESCRIPTION
…correct issues where test was failing in other timezones.

Signed-off-by: ed.snodgrass <snodgrass.ed@gmail.com>