### PR TITLE
App settings store and some cleanup

### DIFF
--- a/react/client/.eslintrc.js
+++ b/react/client/.eslintrc.js
@@ -1,0 +1,37 @@
+module.exports = {
+  env: {
+    browser: true,
+    es2021: true,
+  },
+  extends: [
+    'plugin:react/recommended',
+    'plugin:jest/recommended',
+    'plugin:react-hooks/recommended',
+  ],
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+    ecmaVersion: 12,
+    sourceType: 'module',
+  },
+  plugins: [
+    'react',
+    'jest',
+  ],
+  rules: {
+    quotes: ['warn', 'single'],
+    semi: ['warn', 'never'],
+    camelcase: 'warn',
+  },
+  overrides: [
+    {
+      files: [
+        '**/*.test.js',
+      ],
+      env: {
+        jest: true,
+      },
+    },
+  ],
+}

--- a/react/client/package-lock.json
+++ b/react/client/package-lock.json
@@ -8,9 +8,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@reduxjs/toolkit": "^1.6.1",
-        "@testing-library/jest-dom": "^5.14.1",
-        "@testing-library/react": "^11.2.7",
-        "@testing-library/user-event": "^12.8.3",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-redux": "^7.2.4",
@@ -18,6 +15,11 @@
         "react-scripts": "4.0.3",
         "styled-components": "^5.3.0",
         "web-vitals": "^1.1.2"
+      },
+      "devDependencies": {
+        "@testing-library/jest-dom": "^5.14.1",
+        "@testing-library/react": "^11.2.7",
+        "@testing-library/user-event": "^12.8.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3065,6 +3067,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.1.0.tgz",
       "integrity": "sha512-kmW9alndr19qd6DABzQ978zKQ+J65gU2Rzkl8hriIetPnwpesRaK4//jEQyYh8fEALmGhomD/LBQqt+o+DL95Q==",
+      "dev": true,
       "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
@@ -3084,6 +3087,7 @@
       "version": "7.14.8",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.8.tgz",
       "integrity": "sha512-twj3L8Og5SaCRCErB4x4ajbvBIVV77CGeFglHpeg5WC5FF8TZzBWXtTJ4MqaD9QszLYTtr+IsaAL2rEUevb+eg==",
+      "dev": true,
       "peer": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
@@ -3096,6 +3100,7 @@
       "version": "27.0.6",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
       "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
+      "dev": true,
       "peer": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -3112,6 +3117,7 @@
       "version": "16.0.4",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
       "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+      "dev": true,
       "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -3121,6 +3127,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3136,6 +3143,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
       "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
       "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -3152,6 +3160,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3164,12 +3173,14 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "peer": true
     },
     "node_modules/@testing-library/dom/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -3179,6 +3190,7 @@
       "version": "27.0.6",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.6.tgz",
       "integrity": "sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==",
+      "dev": true,
       "peer": true,
       "dependencies": {
         "@jest/types": "^27.0.6",
@@ -3194,6 +3206,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=10"
@@ -3206,6 +3219,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -3218,6 +3232,7 @@
       "version": "5.14.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.14.1.tgz",
       "integrity": "sha512-dfB7HVIgTNCxH22M1+KU6viG5of2ldoA5ly8Ar8xkezKHKXjRvznCdbMbqjYGgO2xjRbwnR+rR8MLUIqF3kKbQ==",
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.9.2",
         "@types/testing-library__jest-dom": "^5.9.1",
@@ -3239,6 +3254,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -3253,6 +3269,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
       "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -3265,6 +3282,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -3275,12 +3293,14 @@
     "node_modules/@testing-library/jest-dom/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/@testing-library/jest-dom/node_modules/css": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
       "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.4",
         "source-map": "^0.6.1",
@@ -3291,6 +3311,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3299,6 +3320,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3307,6 +3329,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
       "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+      "dev": true,
       "dependencies": {
         "atob": "^2.1.2",
         "decode-uri-component": "^0.2.0"
@@ -3316,6 +3339,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -3327,6 +3351,7 @@
       "version": "11.2.7",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.2.7.tgz",
       "integrity": "sha512-tzRNp7pzd5QmbtXNG/mhdcl7Awfu/Iz1RaVHY75zTdOkmHCuzMhRL83gWHSgOAcjS3CCbyfwUHMZgRJb4kAfpA==",
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@testing-library/dom": "^7.28.1"
@@ -3343,6 +3368,7 @@
       "version": "7.14.8",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.8.tgz",
       "integrity": "sha512-twj3L8Og5SaCRCErB4x4ajbvBIVV77CGeFglHpeg5WC5FF8TZzBWXtTJ4MqaD9QszLYTtr+IsaAL2rEUevb+eg==",
+      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -3354,6 +3380,7 @@
       "version": "7.31.2",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.31.2.tgz",
       "integrity": "sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3372,6 +3399,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -3386,6 +3414,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
       "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -3401,6 +3430,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -3411,12 +3441,14 @@
     "node_modules/@testing-library/react/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/@testing-library/react/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3425,6 +3457,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -3436,6 +3469,7 @@
       "version": "12.8.3",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.8.3.tgz",
       "integrity": "sha512-IR0iWbFkgd56Bu5ZI/ej8yQwrkCv8Qydx6RzwbKz9faXazR/+5tvYKsZQgyXJiwgpcva127YO6JcWy7YlCfofQ==",
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5"
       },
@@ -3451,6 +3485,7 @@
       "version": "7.14.8",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.8.tgz",
       "integrity": "sha512-twj3L8Og5SaCRCErB4x4ajbvBIVV77CGeFglHpeg5WC5FF8TZzBWXtTJ4MqaD9QszLYTtr+IsaAL2rEUevb+eg==",
+      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -3469,7 +3504,8 @@
     "node_modules/@types/aria-query": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
-      "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig=="
+      "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.1.15",
@@ -3578,6 +3614,7 @@
       "version": "26.0.24",
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.24.tgz",
       "integrity": "sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==",
+      "dev": true,
       "dependencies": {
         "jest-diff": "^26.0.0",
         "pretty-format": "^26.0.0"
@@ -3676,6 +3713,7 @@
       "version": "5.14.1",
       "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.1.tgz",
       "integrity": "sha512-Gk9vaXfbzc5zCXI9eYE9BI5BNHEp4D3FWjgqBE/ePGYElLAP+KvxBcsdkwfIVvezs605oiyd/VrpiHe3Oeg+Aw==",
+      "dev": true,
       "dependencies": {
         "@types/jest": "*"
       }
@@ -6538,7 +6576,8 @@
     "node_modules/css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s="
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
+      "dev": true
     },
     "node_modules/css/node_modules/source-map": {
       "version": "0.6.1",
@@ -7219,7 +7258,8 @@
     "node_modules/dom-accessibility-api": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.6.tgz",
-      "integrity": "sha512-DplGLZd8L1lN64jlT27N9TVSESFR5STaEJvX+thCby7fuCHonfPpAlodYc3vuUYbDuDec5w8AMP7oCM5TWFsqw=="
+      "integrity": "sha512-DplGLZd8L1lN64jlT27N9TVSESFR5STaEJvX+thCby7fuCHonfPpAlodYc3vuUYbDuDec5w8AMP7oCM5TWFsqw==",
+      "dev": true
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -13267,6 +13307,7 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
       "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "dev": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -13460,6 +13501,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -16877,6 +16919,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
       "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
       "dependencies": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
@@ -18851,6 +18894,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
       "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
       "dependencies": {
         "min-indent": "^1.0.0"
       },
@@ -24003,6 +24047,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.1.0.tgz",
       "integrity": "sha512-kmW9alndr19qd6DABzQ978zKQ+J65gU2Rzkl8hriIetPnwpesRaK4//jEQyYh8fEALmGhomD/LBQqt+o+DL95Q==",
+      "dev": true,
       "peer": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
@@ -24019,6 +24064,7 @@
           "version": "7.14.8",
           "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.8.tgz",
           "integrity": "sha512-twj3L8Og5SaCRCErB4x4ajbvBIVV77CGeFglHpeg5WC5FF8TZzBWXtTJ4MqaD9QszLYTtr+IsaAL2rEUevb+eg==",
+          "dev": true,
           "peer": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
@@ -24028,6 +24074,7 @@
           "version": "27.0.6",
           "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
           "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
+          "dev": true,
           "peer": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -24041,6 +24088,7 @@
           "version": "16.0.4",
           "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
           "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+          "dev": true,
           "peer": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -24050,6 +24098,7 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
           "peer": true,
           "requires": {
             "color-convert": "^2.0.1"
@@ -24059,6 +24108,7 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
           "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "dev": true,
           "peer": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -24069,6 +24119,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
           "peer": true,
           "requires": {
             "color-name": "~1.1.4"
@@ -24078,18 +24129,21 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true,
           "peer": true
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true,
           "peer": true
         },
         "pretty-format": {
           "version": "27.0.6",
           "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.6.tgz",
           "integrity": "sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==",
+          "dev": true,
           "peer": true,
           "requires": {
             "@jest/types": "^27.0.6",
@@ -24102,6 +24156,7 @@
               "version": "5.2.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
               "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+              "dev": true,
               "peer": true
             }
           }
@@ -24110,6 +24165,7 @@
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
           "peer": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -24121,6 +24177,7 @@
       "version": "5.14.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.14.1.tgz",
       "integrity": "sha512-dfB7HVIgTNCxH22M1+KU6viG5of2ldoA5ly8Ar8xkezKHKXjRvznCdbMbqjYGgO2xjRbwnR+rR8MLUIqF3kKbQ==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.9.2",
         "@types/testing-library__jest-dom": "^5.9.1",
@@ -24137,6 +24194,7 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -24145,6 +24203,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
           "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -24154,6 +24213,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -24161,12 +24221,14 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         },
         "css": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
           "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
+          "dev": true,
           "requires": {
             "inherits": "^2.0.4",
             "source-map": "^0.6.1",
@@ -24176,17 +24238,20 @@
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
         },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         },
         "source-map-resolve": {
           "version": "0.6.0",
           "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
           "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+          "dev": true,
           "requires": {
             "atob": "^2.1.2",
             "decode-uri-component": "^0.2.0"
@@ -24196,6 +24261,7 @@
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -24206,6 +24272,7 @@
       "version": "11.2.7",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.2.7.tgz",
       "integrity": "sha512-tzRNp7pzd5QmbtXNG/mhdcl7Awfu/Iz1RaVHY75zTdOkmHCuzMhRL83gWHSgOAcjS3CCbyfwUHMZgRJb4kAfpA==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@testing-library/dom": "^7.28.1"
@@ -24215,6 +24282,7 @@
           "version": "7.14.8",
           "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.8.tgz",
           "integrity": "sha512-twj3L8Og5SaCRCErB4x4ajbvBIVV77CGeFglHpeg5WC5FF8TZzBWXtTJ4MqaD9QszLYTtr+IsaAL2rEUevb+eg==",
+          "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -24223,6 +24291,7 @@
           "version": "7.31.2",
           "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.31.2.tgz",
           "integrity": "sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==",
+          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.10.4",
             "@babel/runtime": "^7.12.5",
@@ -24238,6 +24307,7 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -24246,6 +24316,7 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
           "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -24255,6 +24326,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -24262,17 +24334,20 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -24283,6 +24358,7 @@
       "version": "12.8.3",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.8.3.tgz",
       "integrity": "sha512-IR0iWbFkgd56Bu5ZI/ej8yQwrkCv8Qydx6RzwbKz9faXazR/+5tvYKsZQgyXJiwgpcva127YO6JcWy7YlCfofQ==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5"
       },
@@ -24291,6 +24367,7 @@
           "version": "7.14.8",
           "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.8.tgz",
           "integrity": "sha512-twj3L8Og5SaCRCErB4x4ajbvBIVV77CGeFglHpeg5WC5FF8TZzBWXtTJ4MqaD9QszLYTtr+IsaAL2rEUevb+eg==",
+          "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -24305,7 +24382,8 @@
     "@types/aria-query": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
-      "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig=="
+      "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
+      "dev": true
     },
     "@types/babel__core": {
       "version": "7.1.15",
@@ -24414,6 +24492,7 @@
       "version": "26.0.24",
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.24.tgz",
       "integrity": "sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==",
+      "dev": true,
       "requires": {
         "jest-diff": "^26.0.0",
         "pretty-format": "^26.0.0"
@@ -24512,6 +24591,7 @@
       "version": "5.14.1",
       "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.1.tgz",
       "integrity": "sha512-Gk9vaXfbzc5zCXI9eYE9BI5BNHEp4D3FWjgqBE/ePGYElLAP+KvxBcsdkwfIVvezs605oiyd/VrpiHe3Oeg+Aw==",
+      "dev": true,
       "requires": {
         "@types/jest": "*"
       }
@@ -26792,7 +26872,8 @@
     "css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s="
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
+      "dev": true
     },
     "cssdb": {
       "version": "4.4.0",
@@ -27328,7 +27409,8 @@
     "dom-accessibility-api": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.6.tgz",
-      "integrity": "sha512-DplGLZd8L1lN64jlT27N9TVSESFR5STaEJvX+thCby7fuCHonfPpAlodYc3vuUYbDuDec5w8AMP7oCM5TWFsqw=="
+      "integrity": "sha512-DplGLZd8L1lN64jlT27N9TVSESFR5STaEJvX+thCby7fuCHonfPpAlodYc3vuUYbDuDec5w8AMP7oCM5TWFsqw==",
+      "dev": true
     },
     "dom-converter": {
       "version": "0.2.0",
@@ -31850,7 +31932,8 @@
     "lz-string": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY="
+      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "dev": true
     },
     "magic-string": {
       "version": "0.25.7",
@@ -32002,7 +32085,8 @@
     "min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true
     },
     "mini-create-react-context": {
       "version": "0.4.1",
@@ -34721,6 +34805,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
       "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
       "requires": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
@@ -36312,6 +36397,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
       "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
       "requires": {
         "min-indent": "^1.0.0"
       }

--- a/react/client/package-lock.json
+++ b/react/client/package-lock.json
@@ -13,13 +13,22 @@
         "react-redux": "^7.2.4",
         "react-router-dom": "^5.2.0",
         "react-scripts": "4.0.3",
+        "redux": "^4.1.0",
+        "redux-thunk": "^2.3.0",
+        "reselect": "^4.0.0",
         "styled-components": "^5.3.0",
         "web-vitals": "^1.1.2"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^11.2.7",
-        "@testing-library/user-event": "^12.8.3"
+        "@testing-library/user-event": "^12.8.3",
+        "eslint": "^7.31.0",
+        "eslint-plugin-import": "^2.23.4",
+        "eslint-plugin-jest": "^24.4.0",
+        "eslint-plugin-jsx-a11y": "^6.4.1",
+        "eslint-plugin-react": "^7.24.0",
+        "eslint-plugin-react-hooks": "^4.2.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -8005,9 +8014,9 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "24.3.7",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.3.7.tgz",
-      "integrity": "sha512-pXED2NA4q2M/5mxlN6GyuUXAFJndT0uosOkQCHaUED9pqgBPd89ZzpcZEU6c5HtZNahC00M36FkwLdDHMDqaHw==",
+      "version": "24.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.4.0.tgz",
+      "integrity": "sha512-8qnt/hgtZ94E9dA6viqfViKBfkJwFHXgJmTWlMGDgunw1XJEGqm3eiPjDsTanM3/u/3Az82nyQM9GX7PM/QGmg==",
       "dependencies": {
         "@typescript-eslint/experimental-utils": "^4.0.1"
       },
@@ -28073,9 +28082,9 @@
       }
     },
     "eslint-plugin-jest": {
-      "version": "24.3.7",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.3.7.tgz",
-      "integrity": "sha512-pXED2NA4q2M/5mxlN6GyuUXAFJndT0uosOkQCHaUED9pqgBPd89ZzpcZEU6c5HtZNahC00M36FkwLdDHMDqaHw==",
+      "version": "24.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.4.0.tgz",
+      "integrity": "sha512-8qnt/hgtZ94E9dA6viqfViKBfkJwFHXgJmTWlMGDgunw1XJEGqm3eiPjDsTanM3/u/3Az82nyQM9GX7PM/QGmg==",
       "requires": {
         "@typescript-eslint/experimental-utils": "^4.0.1"
       }

--- a/react/client/package.json
+++ b/react/client/package.json
@@ -4,9 +4,6 @@
   "private": true,
   "dependencies": {
     "@reduxjs/toolkit": "^1.6.1",
-    "@testing-library/jest-dom": "^5.14.1",
-    "@testing-library/react": "^11.2.7",
-    "@testing-library/user-event": "^12.8.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-redux": "^7.2.4",
@@ -14,6 +11,11 @@
     "react-scripts": "4.0.3",
     "styled-components": "^5.3.0",
     "web-vitals": "^1.1.2"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^5.14.1",
+    "@testing-library/react": "^11.2.7",
+    "@testing-library/user-event": "^12.8.3"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/react/client/package.json
+++ b/react/client/package.json
@@ -9,19 +9,29 @@
     "react-redux": "^7.2.4",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
+    "redux": "^4.1.0",
+    "redux-thunk": "^2.3.0",
+    "reselect": "^4.0.0",
     "styled-components": "^5.3.0",
     "web-vitals": "^1.1.2"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^11.2.7",
-    "@testing-library/user-event": "^12.8.3"
+    "@testing-library/user-event": "^12.8.3",
+    "eslint": "^7.31.0",
+    "eslint-plugin-import": "^2.23.4",
+    "eslint-plugin-jest": "^24.4.0",
+    "eslint-plugin-jsx-a11y": "^6.4.1",
+    "eslint-plugin-react": "^7.24.0",
+    "eslint-plugin-react-hooks": "^4.2.0"
   },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "lint": "eslint"
   },
   "eslintConfig": {
     "extends": [

--- a/react/client/src/screens/LandingPage/index.js
+++ b/react/client/src/screens/LandingPage/index.js
@@ -1,10 +1,12 @@
-import React, { useEffect }from 'react'
+import React, { useEffect } from 'react'
+import { useSelector } from "react-redux"
 import * as TL from './styles' // Stands for "Truth Loop"
 
 import { useDemoStartActions } from '../../hooks/demoStart'
 
 const DemoStart = () => {
   const { demoStart } = useDemoStartActions()
+  const appTitle = useSelector(({ appSettings }) => appSettings.appTitle)
 
   useEffect(() => {
     // Just to don't persist that data on Storage.
@@ -15,7 +17,7 @@ const DemoStart = () => {
   return (
     <TL.MainContainer>
       <TL.Title>
-        Hey folks, Hello from React!!! 😎
+        Hey folks, Welcome to {appTitle}
       </TL.Title>
     </TL.MainContainer>
   )

--- a/react/client/src/screens/LandingPage/index.js
+++ b/react/client/src/screens/LandingPage/index.js
@@ -1,17 +1,16 @@
-import React, { useEffect } from 'react'
-
+import React, { useEffect }from 'react'
 import * as TL from './styles' // Stands for "Truth Loop"
 
-import { useDemoStartActions } from '../../hooks/demoStart'
+import { useDemoStartActions } from '../../hooks/demoStart'
 
 const DemoStart = () => {
-  const { demoStart } = useDemoStartActions()
+  const { demoStart } = useDemoStartActions()
 
   useEffect(() => {
     // Just to don't persist that data on Storage.
     localStorage.clear()
     demoStart('Hello from REDUX')
-  }, [])
+  }, [demoStart])
 
   return (
     <TL.MainContainer>

--- a/react/client/src/screens/LandingPage/styles.js
+++ b/react/client/src/screens/LandingPage/styles.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { commonVariables } from '../../styles/variables'
+import { commonVariables } from '../../styles/variables'
 
 export const MainContainer = styled.div`
   display: flex;

--- a/react/client/src/store/index.js
+++ b/react/client/src/store/index.js
@@ -3,6 +3,7 @@ import thunk from 'redux-thunk'
 
 import demoStartReducer from './reducers/demoStart/reducer'
 import appSettingsReducer from './reducers/appSettings.duck'
+import policyListReducer from './reducers/policyList.duck'
 
 const saveToLocalStorage = (state) => {
   try {
@@ -27,6 +28,7 @@ export const configureStore = () => {
   const reducers = combineReducers({
     demoStart: demoStartReducer,
     appSettings: appSettingsReducer,
+    policyList: policyListReducer,
   })
 
   const middleware = [thunk]

--- a/react/client/src/store/index.js
+++ b/react/client/src/store/index.js
@@ -2,6 +2,7 @@ import { createStore, applyMiddleware, combineReducers, compose } from 'redux'
 import thunk from 'redux-thunk'
 
 import demoStartReducer from './reducers/demoStart/reducer'
+import appSettingsReducer from './reducers/appSettings.duck'
 
 const saveToLocalStorage = (state) => {
   try {
@@ -25,6 +26,7 @@ export const configureStore = () => {
 
   const reducers = combineReducers({
     demoStart: demoStartReducer,
+    appSettings: appSettingsReducer,
   })
 
   const middleware = [thunk]
@@ -37,7 +39,7 @@ export const configureStore = () => {
     persistedStore,
     enhancers(applyMiddleware(...middleware))
   )
-  
+
   store.subscribe(() => {
     saveToLocalStorage(store.getState())
   })

--- a/react/client/src/store/index.js
+++ b/react/client/src/store/index.js
@@ -6,7 +6,7 @@ import appSettingsReducer from './reducers/appSettings.duck'
 
 const saveToLocalStorage = (state) => {
   try {
-    localStorage.setItem('state', JSON.stringify(state));
+    localStorage.setItem('state', JSON.stringify(state))
   } catch (e) {
     console.error(e)
   }

--- a/react/client/src/store/reducers/appSettings.duck.js
+++ b/react/client/src/store/reducers/appSettings.duck.js
@@ -1,4 +1,4 @@
-export const APP_SETTINGS_UPDATE = "truth-loop/appSettings/update"
+export const APP_SETTINGS_UPDATE = 'truth-loop/appSettings/update'
 
 export const DEFAULT_STATE = {
   appTitle: 'Truth Loop',
@@ -12,15 +12,15 @@ export default function reducer(state = DEFAULT_STATE, action = {}) {
   switch (action.type) {
     case APP_SETTINGS_UPDATE: {
       const newState = {...state}
-      if (action.payload.appTitle != null && typeof action.payload.appTitle !== "undefined") {
-        newState.appTitle = action.payload.appTitle;
+      if (action.payload.appTitle != null && typeof action.payload.appTitle !== 'undefined') {
+        newState.appTitle = action.payload.appTitle
       }
       if (action.payload.topBar) {
-        if (action.payload.topBar.hasBack != null && typeof action.payload.topBar.hasBack !== "undefined") {
-          newState.topBar.hasBack = action.payload.topBar.hasBack;
+        if (action.payload.topBar.hasBack != null && typeof action.payload.topBar.hasBack !== 'undefined') {
+          newState.topBar.hasBack = action.payload.topBar.hasBack
         }
-        if (action.payload.topBar.hasSettings != null && typeof action.payload.topBar.hasSettings !== "undefined") {
-          newState.topBar.hasSettings = action.payload.topBar.hasSettings;
+        if (action.payload.topBar.hasSettings != null && typeof action.payload.topBar.hasSettings !== 'undefined') {
+          newState.topBar.hasSettings = action.payload.topBar.hasSettings
         }
       }
       return newState

--- a/react/client/src/store/reducers/appSettings.duck.js
+++ b/react/client/src/store/reducers/appSettings.duck.js
@@ -1,0 +1,37 @@
+export const APP_SETTINGS_UPDATE = "truth-loop/appSettings/update"
+
+export const DEFAULT_STATE = {
+  appTitle: 'Truth Loop',
+  topBar: {
+    hasBack: false,
+    hasSettings: false,
+  },
+}
+
+export default function reducer(state = DEFAULT_STATE, action = {}) {
+  switch (action.type) {
+    case APP_SETTINGS_UPDATE: {
+      const newState = {...state}
+      if (action.payload.appTitle != null && typeof action.payload.appTitle !== "undefined") {
+        newState.appTitle = action.payload.appTitle;
+      }
+      if (action.payload.topBar) {
+        if (action.payload.topBar.hasBack != null && typeof action.payload.topBar.hasBack !== "undefined") {
+          newState.topBar.hasBack = action.payload.topBar.hasBack;
+        }
+        if (action.payload.topBar.hasSettings != null && typeof action.payload.topBar.hasSettings !== "undefined") {
+          newState.topBar.hasSettings = action.payload.topBar.hasSettings;
+        }
+      }
+      return newState
+    }
+    default:
+      return state
+  }
+}
+
+export function updateAppSettings(appSettings) {
+  return dispatch => {
+    return dispatch({type: APP_SETTINGS_UPDATE, payload: appSettings})
+  }
+}

--- a/react/client/src/store/reducers/appSettings.duck.test.js
+++ b/react/client/src/store/reducers/appSettings.duck.test.js
@@ -1,0 +1,134 @@
+import reducer, {
+  APP_SETTINGS_UPDATE,
+  DEFAULT_STATE
+} from './appSettings.duck'
+
+describe('appSettings reducer tests', () => {
+  let state, initialState
+  beforeEach(() => {
+    initialState = {
+      appTitle: '',
+      topBar: {
+        hasBack: false,
+        hasSettings: false,
+      },
+    }
+  })
+
+  describe('when just updating the appTitle', () => {
+    beforeEach(() => {
+      state = reducer(initialState, {type: APP_SETTINGS_UPDATE, payload: {appTitle: 'the new title'}})
+    })
+    it('should update the title', () => {
+      expect(state.appTitle).toEqual('the new title')
+    })
+    it('should not update topBar.hasBack', () => {
+      expect(state.topBar.hasBack).toBeFalsy()
+    })
+    it('topBar.hasBack should be defined', () => {
+      expect(state.topBar.hasBack).toBeDefined()
+    })
+    it('should not update topBar.hasSettings', () => {
+      expect(state.topBar.hasSettings).toBeFalsy()
+    })
+    it('topBar.hasSettings should be defined', () => {
+      expect(state.topBar.hasSettings).toBeDefined()
+    })
+  })
+
+  describe('when appTitle is undefined', () => {
+    beforeEach(() => {
+      state = reducer(initialState, {type: APP_SETTINGS_UPDATE, payload: {appTitle: undefined}})
+    })
+    it('should not update the title', () => {
+      expect(state.appTitle).toEqual('')
+    })
+  })
+
+  describe('when updating topBar.hasBack', () => {
+    beforeEach(() => {
+      state = reducer(initialState, {type: APP_SETTINGS_UPDATE, payload: {topBar: {hasBack: true}}})
+    })
+    it('should update topBar.hasBack', () => {
+      expect(state.topBar.hasBack).toBeTruthy()
+    })
+    it('topBar.hasBack should be defined', () => {
+      expect(state.topBar.hasBack).toBeDefined()
+    })
+    it('should not update topBar.hasSettings', () => {
+      expect(state.topBar.hasSettings).toBeFalsy()
+    })
+    it('topBar.hasSettings should be defined', () => {
+      expect(state.topBar.hasSettings).toBeDefined()
+    })
+    it('should not update the title', () => {
+      expect(state.appTitle).toEqual('')
+    })
+  })
+
+  describe('when updating topBar.hasSettings', () => {
+    beforeEach(() => {
+      state = reducer(initialState, {type: APP_SETTINGS_UPDATE, payload: {topBar: {hasSettings: true}}})
+    })
+    it('should update topBar.hasSettings', () => {
+      expect(state.topBar.hasSettings).toBeTruthy()
+    })
+    it('should not update topBar.hasBack', () => {
+      expect(state.topBar.hasBack).toBeFalsy()
+    })
+    it('topBar.hasBack should be defined', () => {
+      expect(state.topBar.hasBack).toBeDefined()
+    })
+    it('should not update the title', () => {
+      expect(state.appTitle).toEqual('')
+    })
+  })
+
+  describe('when topBar.hasBack is undefined', () => {
+    beforeEach(() => {
+      state = reducer(initialState, {type: APP_SETTINGS_UPDATE, payload: {topBar: {hasBack: undefined}}})
+    })
+    it('should not update topBar.hasBack', () => {
+      expect(state.topBar.hasBack).toBeFalsy()
+    })
+    it('topBar.hasBack should be defined', () => {
+      expect(state.topBar.hasBack).toBeDefined()
+    })
+    it('should not update topBar.hasSettings', () => {
+      expect(state.topBar.hasSettings).toBeFalsy()
+    })
+    it('topBar.hasSettings should be defined', () => {
+      expect(state.topBar.hasSettings).toBeDefined()
+    })
+    it('should not update the title', () => {
+      expect(state.appTitle).toEqual('')
+    })
+  })
+
+  describe('when topBar.hasSettings is undefined', () => {
+    beforeEach(() => {
+      state = reducer(initialState, {type: APP_SETTINGS_UPDATE, payload: {topBar: {hasSettings: undefined}}})
+    })
+    it('should not update topBar.hasSettings', () => {
+      expect(state.topBar.hasSettings).toBeFalsy()
+    })
+    it('topBar.hasSettings should be defined', () => {
+      expect(state.topBar.hasSettings).toBeDefined()
+    })
+    it('should not update topBar.hasBack', () => {
+      expect(state.topBar.hasBack).toBeFalsy()
+    })
+    it('topBar.hasBack should be defined', () => {
+      expect(state.topBar.hasBack).toBeDefined()
+    })
+    it('should not update the title', () => {
+      expect(state.appTitle).toEqual('')
+    })
+  })
+
+  describe('when no initial state exists', () => {
+    it('should return the default state', () => {
+      expect(reducer(undefined, {})).toEqual(DEFAULT_STATE)
+    })
+  })
+})

--- a/react/client/src/store/reducers/demoStart/actions.js
+++ b/react/client/src/store/reducers/demoStart/actions.js
@@ -9,4 +9,4 @@ const demoStartAction = (data) => {
   }
 }
 
-export { demoStartAction }
+export { demoStartAction }

--- a/react/client/src/store/reducers/policyList.duck.js
+++ b/react/client/src/store/reducers/policyList.duck.js
@@ -1,0 +1,39 @@
+export const POLICY_LIST_ITEMS_UPDATE = 'truth-loop/policyList/itemsUpdate'
+export const POLICY_LIST_ITEM_DETAILS_UPDATE = 'truth-loop/policyList/itemDetailsUpdate'
+
+export const DEFAULT_STATE = {
+  items: [],
+  itemCount: 0,
+  selectedItemDetails: null,
+}
+
+export default function reducer(state = DEFAULT_STATE, action = {}) {
+  switch (action.type) {
+    case POLICY_LIST_ITEMS_UPDATE: {
+      if (action.payload != null && typeof action.payload !== 'undefined') {
+        return { ...state, items: action.payload, itemCount: action.payload.length }
+      }
+      return state
+    }
+    case POLICY_LIST_ITEM_DETAILS_UPDATE: {
+      if (action.payload != null && typeof action.payload !== 'undefined') {
+        return { ...state, selectedItemDetails: action.payload }
+      }
+      return state
+    }
+    default:
+      return state
+  }
+}
+
+export function updateItems(items) {
+  return dispatch => {
+    return dispatch({type: POLICY_LIST_ITEMS_UPDATE, payload: items})
+  }
+}
+
+export function updateItemDetails(itemDetails) {
+  return dispatch => {
+    return dispatch({type: POLICY_LIST_ITEM_DETAILS_UPDATE, payload: itemDetails})
+  }
+}

--- a/react/client/src/store/reducers/policyList.duck.test.js
+++ b/react/client/src/store/reducers/policyList.duck.test.js
@@ -1,0 +1,82 @@
+import reducer, {DEFAULT_STATE, POLICY_LIST_ITEM_DETAILS_UPDATE, POLICY_LIST_ITEMS_UPDATE} from './policyList.duck'
+
+describe('policyList reducer tests', () => {
+  let state, initialState
+  beforeEach(() => {
+    initialState = { ...DEFAULT_STATE }
+  })
+
+  describe('POLICY_LIST_ITEMS_UPDATE tests', () => {
+    describe('when passing new items', () => {
+      beforeEach(() => {
+        state = reducer(initialState, {type: POLICY_LIST_ITEMS_UPDATE, payload: ['a', 'b']})
+      })
+      it('should update items', () => {
+        expect(state.items).toEqual(['a', 'b'])
+      })
+      it('should update itemCount', () => {
+        expect(state.itemCount).toEqual(2)
+      })
+    })
+    describe('when passing null as payload', () => {
+      beforeEach(() => {
+        state = reducer(initialState, {type: POLICY_LIST_ITEMS_UPDATE, payload: null})
+      })
+      it('should not update items', () => {
+        expect(state.items).toEqual([])
+      })
+      it('should not update itemCount', () => {
+        expect(state.itemCount).toEqual(0)
+      })
+    })
+    describe('when passing undefined as payload', () => {
+      beforeEach(() => {
+        state = reducer(initialState, {type: POLICY_LIST_ITEMS_UPDATE, payload: undefined})
+      })
+      it('should not update items', () => {
+        expect(state.items).toEqual([])
+      })
+      it('should not update itemCount', () => {
+        expect(state.itemCount).toEqual(0)
+      })
+    })
+  })
+
+  describe('POLICY_LIST_ITEM_DETAILS_UPDATE tests', () => {
+    describe('when passing new itemDetails', () => {
+      beforeEach(() => {
+        state = reducer({ ...initialState, selectedItemDetails: 'Test Details' }, {type: POLICY_LIST_ITEM_DETAILS_UPDATE, payload: 'updated details'})
+      })
+      it('should update selectedItemDetails', () => {
+        expect(state.selectedItemDetails).toEqual('updated details')
+      })
+    })
+    describe('when passing null as payload', () => {
+      beforeEach(() => {
+        state = reducer({ ...initialState, selectedItemDetails: 'Test Details' }, {type: POLICY_LIST_ITEM_DETAILS_UPDATE, payload: null})
+      })
+      it('should not update selectedItemDetails', () => {
+        expect(state.selectedItemDetails).toEqual('Test Details')
+      })
+    })
+    describe('when passing undefined as payload', () => {
+      beforeEach(() => {
+        state = reducer({ ...initialState, selectedItemDetails: 'Test Details' }, {type: POLICY_LIST_ITEM_DETAILS_UPDATE, payload: undefined})
+      })
+      it('should not update selectedItemDetails', () => {
+        expect(state.selectedItemDetails).toEqual('Test Details')
+      })
+    })
+  })
+
+  describe('when no initial state exists', () => {
+    beforeEach(() => {
+      state = reducer(undefined, {})
+    })
+    it('should return the default state', () => {
+      expect(state.items).toEqual([])
+      expect(state.itemCount).toEqual(0)
+      expect(state.selectedItemDetails).toEqual(null)
+    })
+  })
+})


### PR DESCRIPTION
I committed an example of the `duck` file as referenced by https://github.com/erikras/ducks-modular-redux

I tweaked the property names from the vue version to be camelCase (topBar and appSettings).

I updated the LandingPage to select the appTitle from the store just so we can see it in use.


@padilhaalucas maybe we can chat about this. 