### PR TITLE
176 fix publication table conflict

### DIFF
--- a/server/react-admin/src/AdminTable.js
+++ b/server/react-admin/src/AdminTable.js
@@ -1,4 +1,4 @@
-import React, {useState} from 'react'
+import React, {useState, useEffect} from 'react'
 import PropTypes from 'prop-types'
 import Box from '@mui/material/Box'
 import IconButton from '@mui/material/IconButton'
@@ -14,6 +14,8 @@ import TableSortLabel from '@mui/material/TableSortLabel'
 import {visuallyHidden} from '@mui/utils'
 import TableBody from '@mui/material/TableBody'
 import AdminTableToolbar from './AdminTableToolbar'
+import LinearProgress from '@mui/material/LinearProgress'
+import Typography from '@mui/material/Typography'
 
 AdminTable.propTypes = {
   headCells: PropTypes.array.isRequired,
@@ -23,6 +25,7 @@ AdminTable.propTypes = {
   onEditItem: PropTypes.func,
   onDeleteItem: PropTypes.func,
   disableSearch: PropTypes.bool,
+  isLoading: PropTypes.bool,
 }
 
 function descendingComparator(a, b, orderBy) {
@@ -41,9 +44,13 @@ function getComparator(order, orderBy) {
     : (a, b) => -descendingComparator(a, b, orderBy)
 }
 
+function escapeRegExp(value) {
+  return value.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')
+}
+
 function AdminTable(props) {
 
-  const {headCells, rows, caption, tableLabel, onEditItem, onDeleteItem, disableSearch} = props
+  const {headCells, rows, caption, tableLabel, onEditItem, onDeleteItem, disableSearch, isLoading} = props
   const [order, setOrder] = React.useState('asc')
   const [orderBy, setOrderBy] = React.useState('id')
   const [page, setPage] = React.useState(0)
@@ -59,6 +66,7 @@ function AdminTable(props) {
     setOrder(isAsc ? 'desc' : 'asc')
     setOrderBy(property)
   }
+
   const handleChangePage = (event, newPage) => {
     setPage(newPage)
   }
@@ -69,68 +77,85 @@ function AdminTable(props) {
   }
 
   const handleSearchRequest = function(searchText) {
-    const filtered = rows.filter((row) => {
-      return Object.keys(row).some((field) => {
-        return searchText.test(row[field].toString())
+    if (searchText) {
+      const searchRegex = new RegExp(escapeRegExp(searchText), 'i')
+      const filtered = rows.filter((row) => {
+        return Object.keys(row).some((field) => {
+          return searchRegex.test(row[field].toString())
+        })
       })
-    })
-    setFilteredRows(filtered)
-    setPage(0)
+      setFilteredRows(filtered)
+      setPage(0)
+    }
   }
+
+  useEffect(() => {
+    setFilteredRows(rows)
+    setPage(0)
+  }, [setPage, setFilteredRows, rows])
+
   return (
     <>
       <AdminTableToolbar handleSearchRequest={handleSearchRequest} toolbarTitle={tableLabel} disabled={disableSearch}/>
 
       <TableContainer sx={{maxHeight: 600}}>
-        <Table size="small" aria-label={tableLabel} stickyHeader>
-          <caption data-testid={`${tableLabel}Caption`}>{caption}</caption>
-          <TableHead data-testid={`${tableLabel}HeaderRow`}>
-            <TableRow>
-              {headCells.map((headCell) => (
-                <TableCell
-                  key={headCell.id}
-                  align={'left'}
-                  padding={'normal'}
-                  sortDirection={orderBy === headCell.id ? order : false}
-                >
-                  <TableSortLabel
-                    active={orderBy === headCell.id}
-                    direction={orderBy === headCell.id ? order : 'asc'}
-                    onClick={createSortHandler(headCell.id)}
+        { isLoading ?
+          <Box component={'span'} sx={{ p: 2 }}>
+            <Typography component={'h3'} variant={'overline'} sx={{ p: 2 }}>Loading {tableLabel} ...</Typography>
+            <LinearProgress color="secondary" />
+          </Box>
+          :
+          <Table size="small" aria-label={tableLabel} stickyHeader>
+            <caption data-testid={`${tableLabel}Caption`}>{caption}</caption>
+            <TableHead data-testid={`${tableLabel}HeaderRow`}>
+              <TableRow>
+                {headCells.map((headCell) => (
+                  <TableCell
+                    key={headCell.id}
+                    align={'left'}
+                    padding={'normal'}
+                    sortDirection={orderBy === headCell.id ? order : false}
                   >
-                    {headCell.label}
-                    {orderBy === headCell.id ? (<Box component="span" sx={visuallyHidden}>
-                        {order === 'desc' ? 'sorted descending' : 'sorted ascending'}
-                      </Box>) : null}
-                  </TableSortLabel>
-                </TableCell>
-              ))}
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {filteredRows.slice().sort(getComparator(order, orderBy))
-              .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-              .map((row) => (<TableRow data-testid={`${tableLabel}Row`}
-                  key={`${row.id}-row`}
-                  sx={{'&:last-child td, &:last-child th': {border: 0}}}
-                >
-                  {headCells.map(headCell => (
-                    <TableCell key={`${row.id}_${headCell.id}`}>{row[headCell.id]}</TableCell>
-                  ))}
-                  {!!onEditItem && <TableCell padding={'none'} size={'small'}>
-                    <IconButton aria-label="edit" onClick={() => onEditItem(row)} size={'small'}>
-                      <EditIcon />
-                    </IconButton>
-                  </TableCell>}
-                  {!!onDeleteItem && <TableCell padding={'none'} size={'small'}>
-                    <IconButton aria-label="delete" onClick={() => onDeleteItem(row)} size={'small'}>
-                      <DeleteIcon />
-                    </IconButton>
-                  </TableCell>}
-                </TableRow>
-              ))}
-          </TableBody>
-        </Table>
+                    <TableSortLabel
+                      active={orderBy === headCell.id}
+                      direction={orderBy === headCell.id ? order : 'asc'}
+                      onClick={createSortHandler(headCell.id)}
+                    >
+                      {headCell.label}
+                      {orderBy === headCell.id ? (<Box component="span" sx={visuallyHidden}>
+                          {order === 'desc' ? 'sorted descending' : 'sorted ascending'}
+                        </Box>) : null}
+                    </TableSortLabel>
+                  </TableCell>
+                ))}
+              </TableRow>
+            </TableHead>
+
+            <TableBody>
+              {filteredRows.slice().sort(getComparator(order, orderBy))
+                .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+                .map((row) => (<TableRow data-testid={`${tableLabel}Row`}
+                    key={`${row.id}-row`}
+                    sx={{'&:last-child td, &:last-child th': {border: 0}}}
+                  >
+                    {headCells.map(headCell => (
+                      <TableCell key={`${row.id}_${headCell.id}`}>{row[headCell.id]}</TableCell>
+                    ))}
+                    {!!onEditItem && <TableCell padding={'none'} size={'small'}>
+                      <IconButton aria-label="edit" onClick={() => onEditItem(row)} size={'small'}>
+                        <EditIcon />
+                      </IconButton>
+                    </TableCell>}
+                    {!!onDeleteItem && <TableCell padding={'none'} size={'small'}>
+                      <IconButton aria-label="delete" onClick={() => onDeleteItem(row)} size={'small'}>
+                        <DeleteIcon />
+                      </IconButton>
+                    </TableCell>}
+                  </TableRow>
+                ))}
+            </TableBody>
+          </Table>
+        }
       </TableContainer>
       <TablePagination
         rowsPerPageOptions={[10, 25, 100]}

--- a/server/react-admin/src/AdminTable.test.js
+++ b/server/react-admin/src/AdminTable.test.js
@@ -3,6 +3,30 @@ import AdminTable from './AdminTable'
 import {render, screen} from '@testing-library/react'
 
 describe('AdminTable Tests', () => {
+  describe('When loading items', () => {
+    beforeEach(() => {
+      render(<AdminTable rows={[]}
+                         isLoading={true}
+                         headCells={[{id: 'id', label: 'ID'}]}
+                         caption={'Hello Widgets'}
+                         tableLabel={'Widgets'}/>)
+    })
+    it('should show progressBar', () => {
+      expect(screen.getByRole('progressbar')).toBeVisible()
+    })
+  })
+  describe('When done loading items', () => {
+    beforeEach(() => {
+      render(<AdminTable rows={[]}
+                         isLoading={false}
+                         headCells={[{id: 'id', label: 'ID'}]}
+                         caption={'Hello Widgets'}
+                         tableLabel={'Widgets'}/>)
+    })
+    it('should not show progressBar', () => {
+      expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
+    })
+  })
   describe('When first rendering with 1 item', () => {
     beforeEach(() => {
       render(<AdminTable rows={[{id: '1'}]} headCells={[{id: 'id', label: 'ID'}]} caption={'Hello Widgets'} tableLabel={'Widgets'}/>)

--- a/server/react-admin/src/AdminTableToolbar.js
+++ b/server/react-admin/src/AdminTableToolbar.js
@@ -14,16 +14,11 @@ AdminTableToolbar.propTypes = {
   disabled: PropTypes.bool,
 }
 
-function escapeRegExp(value) {
-  return value.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')
-}
-
 function AdminTableToolbar({toolbarTitle, handleSearchRequest, disabled}) {
   const [searchText, setSearchText] = React.useState('')
   const requestSearch = (searchValue) => {
     setSearchText(searchValue)
-    const searchRegex = new RegExp(escapeRegExp(searchValue), 'i')
-    handleSearchRequest(searchRegex)
+    handleSearchRequest(searchValue)
   }
   return (
     <Toolbar sx={{pl: {sm: 2}, pr: {xs: 1, sm: 1}}}>

--- a/server/react-admin/src/publications/PublicationRoute.js
+++ b/server/react-admin/src/publications/PublicationRoute.js
@@ -3,16 +3,20 @@ import PublicationTable from './PublicationTable'
 
 function PublicationRoute() {
   const [publications, setPublications] = useState([])
+  const [loadingPublications, setLoadingPublications] = useState(false)
+
   useEffect(() => {
     async function fetchPublications() {
+      setLoadingPublications(true)
       const publicationsResponse = await fetch('/api/v1/publications')
       return await publicationsResponse.json()
     }
     fetchPublications().then(setPublications)
+    setLoadingPublications(false)
   }, [])
   return (
     <>
-      <PublicationTable publications={publications}/>
+      <PublicationTable publications={publications} isLoading={loadingPublications}/>
     </>
   )
 }

--- a/server/react-admin/src/publications/PublicationTable.js
+++ b/server/react-admin/src/publications/PublicationTable.js
@@ -10,7 +10,8 @@ import DeleteItemDialog from '../form/DeleteItemDialog'
 import Snackbar from '@mui/material/Snackbar'
 
 PublicationTable.propTypes = {
-  publications: PropTypes.array,
+  publications: PropTypes.array.isRequired,
+  isLoading: PropTypes.bool,
 }
 
 const emptyTableCaption = 'No publications available'
@@ -56,12 +57,13 @@ function PublicationTable(props) {
   return (
     <Paper data-testid={'publicationTable'} elevation={12}>
       <AdminTable headCells={headCells}
-                  rows={props.publications ? props.publications.map(publication => ({
+                  isLoading={props.isLoading}
+                  rows={props.publications.map(publication => ({
                       ...publication,
                       created: formatDate(publication.created),
                       updated: formatDate(publication.updated),
                     }
-                  )) : []}
+                  ))}
                   caption={props.publications && props.publications.length ? caption : emptyTableCaption}
                   tableLabel={'Publications'}
                   onEditItem={item => {
@@ -71,7 +73,7 @@ function PublicationTable(props) {
                     setItemToDelete(item)
                   }}
                   disableSearch={!(props.publications && props.publications.length)}/>
-      <Button sx={{m: 2}} variant={'text'} href={'/publications/add'} startIcon={<AddIcon/>}>
+      <Button sx={{m: 2}} variant={'text'} href={'/publications/add'} startIcon={<AddIcon/>} disabled={props.isLoading}>
         Add Publication
       </Button>
       <DeleteItemDialog title={'Delete Publication?'} description={''} open={!!itemToDelete}

--- a/server/react-admin/src/publications/PublicationTable.test.js
+++ b/server/react-admin/src/publications/PublicationTable.test.js
@@ -3,15 +3,26 @@ import PublicationTable from './PublicationTable'
 import {render, screen} from '@testing-library/react'
 
 describe('PublicationTable Tests', () => {
-  describe('When first rendering with null', () => {
+  describe('When loading items', () => {
     beforeEach(() => {
-      render(<PublicationTable publications={null}/>)
+      render(<PublicationTable publications={[]} isLoading={true}/>)
     })
-    it('should show empty data', () => {
-      expect(screen.getByText('No publications available')).toBeVisible()
+    it('should show progressBar', () => {
+      expect(screen.getByRole('progressbar')).toBeVisible()
     })
-    it('should show add button', () => {
-      expect(screen.getByTestId('AddIcon')).toBeVisible()
+    it('should disable add button', () => {
+      expect(screen.getByRole('link', {name: 'Add Publication'})).toHaveAttribute('aria-disabled', 'true')
+    })
+  })
+  describe('When done loading items', () => {
+    beforeEach(() => {
+      render(<PublicationTable publications={[]} isLoading={false}/>)
+    })
+    it('should not show progressBar', () => {
+      expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
+    })
+    it('should disable add button', () => {
+      expect(screen.getByRole('link', {name: 'Add Publication'})).not.toHaveAttribute('aria-disabled', 'true')
     })
   })
   describe('When first rendering with empty array', () => {


### PR DESCRIPTION
Contributes to #176
## What did you do?
Added the 'filteredRows' state back into the AdminTable and now passing the 'disableSearch' flag to the AdminTable down to the AdminTableToolbar. 

## Why did you do it?
Because a merge conflict was causing tests to fail.

## How have you tested it?
Ran the unit tests and ran the react-admin app and checked the /publications route

## Were docs updated if needed?

- [ ] No
- [ ] Yes
- [x] N/A

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new console logs
- [ ] Fixes entire issue
- [x] Partial fix for issue