### PR TITLE
remove done() callback from tests in server/routes tests

### DIFF
--- a/server/routes/advocacy_groups.test.js
+++ b/server/routes/advocacy_groups.test.js
@@ -10,12 +10,11 @@ describe('CRUD TESTS FOR /api/v1/advocacyGroups', function () {
   let id
   let updatedPayload = { ...payload, description: updatedDescription }
 
-  it('Make sure the random descriptions do not match', async (done) => {
+  it('Make sure the random descriptions do not match', async () => {
     expect(payload.description).not.toEqual(updatedDescription)
-    done()
   })
 
-  it('GET should not have the item.', async (done) => {
+  it('GET should not have the item.', async () => {
     let res = await request(app)
       .get('/api/v1/advocacyGroups')
       .set('Accept', 'application/json')
@@ -25,10 +24,9 @@ describe('CRUD TESTS FOR /api/v1/advocacyGroups', function () {
       // NOT!!!
       expect.arrayContaining([expect.objectContaining(payload)])
     )
-    done()
   })
 
-  it('POST creates the item', async (done) => {
+  it('POST creates the item', async () => {
     let res = await request(app)
       .post('/api/v1/advocacyGroups')
       .set('Accept', 'application/json')
@@ -40,10 +38,9 @@ describe('CRUD TESTS FOR /api/v1/advocacyGroups', function () {
 
     // Save the ID for later
     id = res.body.id
-    done()
   })
 
-  it('GET should now include the item', async (done) => {
+  it('GET should now include the item', async () => {
     let res = await request(app)
       .get('/api/v1/advocacyGroups')
       .set('Accept', 'application/json')
@@ -52,10 +49,9 @@ describe('CRUD TESTS FOR /api/v1/advocacyGroups', function () {
     expect(res.body).toEqual(
       expect.arrayContaining([expect.objectContaining(payload)])
     )
-    done()
   })
 
-  it('GET by ID should return item', async (done) => {
+  it('GET by ID should return item', async () => {
     let res = await request(app)
       .get(`/api/v1/advocacyGroups/${id}`)
       .set('Accept', 'application/json')
@@ -63,10 +59,9 @@ describe('CRUD TESTS FOR /api/v1/advocacyGroups', function () {
     expect(res.status).toBe(200)
     expect(res.body).toEqual(expect.objectContaining(payload))
     itemById = res.body
-    done()
   })
 
-  it('PUT by ID to change the description', async (done) => {
+  it('PUT by ID to change the description', async () => {
     updatedPayload = { ...payload, description: updatedDescription }
 
     expect(payload).not.toEqual(updatedPayload)
@@ -79,35 +74,31 @@ describe('CRUD TESTS FOR /api/v1/advocacyGroups', function () {
       .expect(200)
 
     expect(res.status).toBe(200)
-    done()
   })
 
-  it('GET by ID should return ***UPDATED*** item', async (done) => {
+  it('GET by ID should return ***UPDATED*** item', async () => {
     let res = await request(app)
       .get(`/api/v1/advocacyGroups/${id}`)
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
     expect(res.status).toBe(200)
     expect(res.body).toEqual(expect.objectContaining(updatedPayload))
-    done()
   })
 
-  it('DELETE by ID should succeed', async (done) => {
+  it('DELETE by ID should succeed', async () => {
     let res = await request(app)
       .delete(`/api/v1/advocacyGroups/${id}`)
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
     expect(res.status).toBe(200)
-    done()
   })
 
-  it('GET by ID should NOT find an item', async (done) => {
+  it('GET by ID should NOT find an item', async () => {
     let res = await request(app)
       .get(`/api/v1/advocacyGroups/${id}`)
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
     expect(res.status).toBe(404)
     expect(res.body).toEqual({ error: 'Not Found' })
-    done()
   })
 })

--- a/server/routes/categories.test.js
+++ b/server/routes/categories.test.js
@@ -12,12 +12,11 @@ describe('CRUD TESTS FOR /api/v1/categories', function () {
   let itemByName
   let updatedPayload = { ...payload, description: updatedDescription }
 
-  it('Make sure the random descriptions do not match', async (done) => {
+  it('Make sure the random descriptions do not match', async () => {
     expect(payload.description).not.toEqual(updatedDescription)
-    done()
   })
 
-  it('GET should not have the item.', async (done) => {
+  it('GET should not have the item.', async () => {
     let res = await request(app)
       .get('/api/v1/categories')
       .set('Accept', 'application/json')
@@ -27,10 +26,9 @@ describe('CRUD TESTS FOR /api/v1/categories', function () {
       // NOT!!!
       expect.arrayContaining([expect.objectContaining(payload)])
     )
-    done()
   })
 
-  it('POST creates the item', async (done) => {
+  it('POST creates the item', async () => {
     let res = await request(app)
       .post('/api/v1/categories')
       .set('Accept', 'application/json')
@@ -42,10 +40,9 @@ describe('CRUD TESTS FOR /api/v1/categories', function () {
 
     // Save the ID for later
     id = res.body.id
-    done()
   })
 
-  it('GET should now include the item', async (done) => {
+  it('GET should now include the item', async () => {
     let res = await request(app)
       .get('/api/v1/categories')
       .set('Accept', 'application/json')
@@ -54,10 +51,9 @@ describe('CRUD TESTS FOR /api/v1/categories', function () {
     expect(res.body).toEqual(
       expect.arrayContaining([expect.objectContaining(payload)])
     )
-    done()
   })
 
-  it('GET by ID should return item', async (done) => {
+  it('GET by ID should return item', async () => {
     let res = await request(app)
       .get(`/api/v1/categories/${id}`)
       .set('Accept', 'application/json')
@@ -65,10 +61,9 @@ describe('CRUD TESTS FOR /api/v1/categories', function () {
     expect(res.status).toBe(200)
     expect(res.body).toEqual(expect.objectContaining(payload))
     itemById = res.body
-    done()
   })
 
-  it('GET by NAME should return the same item', async (done) => {
+  it('GET by NAME should return the same item', async () => {
     let res = await request(app)
       .get(`/api/v1/categories/name/${payload.name}`)
       .set('Accept', 'application/json')
@@ -77,10 +72,9 @@ describe('CRUD TESTS FOR /api/v1/categories', function () {
     expect(res.body).toEqual(expect.objectContaining(payload))
     itemByName = res.body
     expect(itemByName).toEqual(itemById)
-    done()
   })
 
-  it('PUT by ID to change the description', async (done) => {
+  it('PUT by ID to change the description', async () => {
     updatedPayload = { ...payload, description: updatedDescription }
 
     expect(payload).not.toEqual(updatedPayload)
@@ -93,35 +87,31 @@ describe('CRUD TESTS FOR /api/v1/categories', function () {
       .expect(200)
 
     expect(res.status).toBe(200)
-    done()
   })
 
-  it('GET by ID should return ***UPDATED*** item', async (done) => {
+  it('GET by ID should return ***UPDATED*** item', async () => {
     let res = await request(app)
       .get(`/api/v1/categories/${id}`)
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
     expect(res.status).toBe(200)
     expect(res.body).toEqual(expect.objectContaining(updatedPayload))
-    done()
   })
 
-  it('DELETE by ID should succeed', async (done) => {
+  it('DELETE by ID should succeed', async () => {
     let res = await request(app)
       .delete(`/api/v1/categories/${id}`)
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
     expect(res.status).toBe(200)
-    done()
   })
 
-  it('GET by ID should NOT find an item', async (done) => {
+  it('GET by ID should NOT find an item', async () => {
     let res = await request(app)
       .get(`/api/v1/categories/${id}`)
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
     expect(res.status).toBe(404)
     expect(res.body).toEqual({ error: 'Not Found' })
-    done()
   })
 })

--- a/server/routes/geospatial_definitions.test.js
+++ b/server/routes/geospatial_definitions.test.js
@@ -13,12 +13,11 @@ describe('CRUD TESTS FOR /api/v1/geospatialDefinitions', function () {
   let itemByName
   let updatedPayload = { ...payload, description: updatedDescription }
 
-  it('Make sure the random descriptions do not match', async (done) => {
+  it('Make sure the random descriptions do not match', async () => {
     expect(payload.description).not.toEqual(updatedDescription)
-    done()
   })
 
-  it('GET should not have the item.', async (done) => {
+  it('GET should not have the item.', async () => {
     let res = await request(app)
       .get('/api/v1/geospatialDefinitions')
       .set('Accept', 'application/json')
@@ -28,10 +27,9 @@ describe('CRUD TESTS FOR /api/v1/geospatialDefinitions', function () {
       // NOT!!!
       expect.arrayContaining([expect.objectContaining(payload)])
     )
-    done()
   })
 
-  it('POST creates the item', async (done) => {
+  it('POST creates the item', async () => {
     let res = await request(app)
       .post('/api/v1/geospatialDefinitions')
       .set('Accept', 'application/json')
@@ -43,10 +41,9 @@ describe('CRUD TESTS FOR /api/v1/geospatialDefinitions', function () {
 
     // Save the ID for later
     id = res.body.id
-    done()
   })
 
-  it('GET should now include the item', async (done) => {
+  it('GET should now include the item', async () => {
     let res = await request(app)
       .get('/api/v1/geospatialDefinitions')
       .set('Accept', 'application/json')
@@ -55,10 +52,9 @@ describe('CRUD TESTS FOR /api/v1/geospatialDefinitions', function () {
     expect(res.body).toEqual(
       expect.arrayContaining([expect.objectContaining(payload)])
     )
-    done()
   })
 
-  it('GET by ID should return item', async (done) => {
+  it('GET by ID should return item', async () => {
     let res = await request(app)
       .get(`/api/v1/geospatialDefinitions/${id}`)
       .set('Accept', 'application/json')
@@ -66,10 +62,9 @@ describe('CRUD TESTS FOR /api/v1/geospatialDefinitions', function () {
     expect(res.status).toBe(200)
     expect(res.body).toEqual(expect.objectContaining(payload))
     itemById = res.body
-    done()
   })
 
-  it('GET by NAME should return the same item', async (done) => {
+  it('GET by NAME should return the same item', async () => {
     let res = await request(app)
       .get(`/api/v1/geospatialDefinitions/name/${payload.name}`)
       .set('Accept', 'application/json')
@@ -78,10 +73,9 @@ describe('CRUD TESTS FOR /api/v1/geospatialDefinitions', function () {
     expect(res.body).toEqual(expect.objectContaining(payload))
     itemByName = res.body
     expect(itemByName).toEqual(itemById)
-    done()
   })
 
-  it('PUT by ID to change the description', async (done) => {
+  it('PUT by ID to change the description', async () => {
     updatedPayload = { ...payload, description: updatedDescription }
 
     expect(payload).not.toEqual(updatedPayload)
@@ -94,35 +88,31 @@ describe('CRUD TESTS FOR /api/v1/geospatialDefinitions', function () {
       .expect(200)
 
     expect(res.status).toBe(200)
-    done()
   })
 
-  it('GET by ID should return ***UPDATED*** item', async (done) => {
+  it('GET by ID should return ***UPDATED*** item', async () => {
     let res = await request(app)
       .get(`/api/v1/geospatialDefinitions/${id}`)
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
     expect(res.status).toBe(200)
     expect(res.body).toEqual(expect.objectContaining(updatedPayload))
-    done()
   })
 
-  it('DELETE by ID should succeed', async (done) => {
+  it('DELETE by ID should succeed', async () => {
     let res = await request(app)
       .delete(`/api/v1/geospatialDefinitions/${id}`)
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
     expect(res.status).toBe(200)
-    done()
   })
 
-  it('GET by ID should NOT find an item', async (done) => {
+  it('GET by ID should NOT find an item', async () => {
     let res = await request(app)
       .get(`/api/v1/geospatialDefinitions/${id}`)
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
     expect(res.status).toBe(404)
     expect(res.body).toEqual({ error: 'Not Found' })
-    done()
   })
 })

--- a/server/routes/legislative_artifacts.test.js
+++ b/server/routes/legislative_artifacts.test.js
@@ -11,12 +11,11 @@ describe('CRUD TESTS FOR /api/v1/legislativeArtifacts', function () {
   let itemById
   let updatedPayload = { ...payload, title: updatedTitle }
 
-  it('Make sure the random titles do not match', async (done) => {
+  it('Make sure the random titles do not match', async () => {
     expect(payload.title).not.toEqual(updatedTitle)
-    done()
   })
 
-  it('GET should not have the item.', async (done) => {
+  it('GET should not have the item.', async () => {
     let res = await request(app)
       .get('/api/v1/legislativeArtifacts')
       .set('Accept', 'application/json')
@@ -26,10 +25,9 @@ describe('CRUD TESTS FOR /api/v1/legislativeArtifacts', function () {
       // NOT!!!
       expect.arrayContaining([expect.objectContaining(payload)])
     )
-    done()
   })
 
-  it('POST creates the item', async (done) => {
+  it('POST creates the item', async () => {
     let res = await request(app)
       .post('/api/v1/legislativeArtifacts')
       .set('Accept', 'application/json')
@@ -41,10 +39,9 @@ describe('CRUD TESTS FOR /api/v1/legislativeArtifacts', function () {
 
     // Save the ID for later
     id = res.body.id
-    done()
   })
 
-  it('GET should now include the item', async (done) => {
+  it('GET should now include the item', async () => {
     let res = await request(app)
       .get('/api/v1/legislativeArtifacts')
       .set('Accept', 'application/json')
@@ -54,10 +51,9 @@ describe('CRUD TESTS FOR /api/v1/legislativeArtifacts', function () {
     expect(res.body).toEqual(
       expect.arrayContaining([expect.objectContaining(payload)])
     )
-    done()
   })
 
-  it('GET by ID should return item', async (done) => {
+  it('GET by ID should return item', async () => {
     let res = await request(app)
       .get(`/api/v1/legislativeArtifacts/${id}`)
       .set('Accept', 'application/json')
@@ -65,10 +61,9 @@ describe('CRUD TESTS FOR /api/v1/legislativeArtifacts', function () {
     expect(res.status).toBe(200)
     expect(res.body).toEqual(expect.objectContaining(payload))
     itemById = res.body
-    done()
   })
 
-  it('PUT by ID to change the title', async (done) => {
+  it('PUT by ID to change the title', async () => {
     updatedPayload = { ...payload, title: updatedTitle }
 
     expect(payload).not.toEqual(updatedPayload)
@@ -81,20 +76,18 @@ describe('CRUD TESTS FOR /api/v1/legislativeArtifacts', function () {
       .expect(200)
 
     expect(res.status).toBe(200)
-    done()
   })
 
-  it('GET by ID should return ***UPDATED*** item', async (done) => {
+  it('GET by ID should return ***UPDATED*** item', async () => {
     let res = await request(app)
       .get(`/api/v1/legislativeArtifacts/${id}`)
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
     expect(res.status).toBe(200)
     expect(res.body).toEqual(expect.objectContaining(updatedPayload))
-    done()
   })
 
-  it('GET minDetail should now include the item', async (done) => {
+  it('GET minDetail should now include the item', async () => {
     let res = await request(app)
       .get('/api/v1/legislativeArtifacts/list/minDetail')
       .set('Accept', 'application/json')
@@ -106,39 +99,35 @@ describe('CRUD TESTS FOR /api/v1/legislativeArtifacts', function () {
         expect.objectContaining(updatedPayload)
       )
     }
-    done()
   })
 
-  it('GET by fullDetailObject by ID should return ***UPDATED*** item', async (done) => {
+  it('GET by fullDetailObject by ID should return ***UPDATED*** item', async () => {
     let res = await request(app)
       .get(`/api/v1/legislativeArtifacts/fullDetail/${id}`)
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
     expect(res.status).toBe(200)
     expect(res.body).toEqual(expect.objectContaining(updatedPayload))
-    done()
   })
 
-  it('DELETE by ID should succeed', async (done) => {
+  it('DELETE by ID should succeed', async () => {
     let res = await request(app)
       .delete(`/api/v1/legislativeArtifacts/${id}`)
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
     expect(res.status).toBe(200)
-    done()
   })
 
-  it('GET by ID should NOT find an item', async (done) => {
+  it('GET by ID should NOT find an item', async () => {
     let res = await request(app)
       .get(`/api/v1/legislativeArtifacts/${id}`)
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
     expect(res.status).toBe(404)
     expect(res.body).toEqual({ error: 'Not Found' })
-    done()
   })
 
-  it('POST creates the fullDetail item', async (done) => {
+  it('POST creates the fullDetail item', async () => {
     let res = await request(app)
       .post('/api/v1/legislativeArtifacts')
       .set('Accept', 'application/json')
@@ -150,15 +139,13 @@ describe('CRUD TESTS FOR /api/v1/legislativeArtifacts', function () {
 
     // Save the ID for later
     id = res.body.id
-    done()
   })
 
-  it('DELETE by fullDetailObject by ID should succeed', async (done) => {
+  it('DELETE by fullDetailObject by ID should succeed', async () => {
     let res = await request(app)
       .delete(`/api/v1/legislativeArtifacts/fullDetail/${id}`)
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
     expect(res.status).toBe(200)
-    done()
   })
 })

--- a/server/routes/levels.test.js
+++ b/server/routes/levels.test.js
@@ -12,12 +12,11 @@ describe('CRUD TESTS FOR /api/v1/levels', function () {
   let itemByName
   let updatedPayload = { ...payload, description: updatedDescription }
 
-  it('Make sure the random descriptions do not match', async (done) => {
+  it('Make sure the random descriptions do not match', async () => {
     expect(payload.description).not.toEqual(updatedDescription)
-    done()
   })
 
-  it('GET should not have the item.', async (done) => {
+  it('GET should not have the item.', async () => {
     let res = await request(app)
       .get('/api/v1/levels')
       .set('Accept', 'application/json')
@@ -27,10 +26,9 @@ describe('CRUD TESTS FOR /api/v1/levels', function () {
       // NOT!!!
       expect.arrayContaining([expect.objectContaining(payload)])
     )
-    done()
   })
 
-  it('POST creates the item', async (done) => {
+  it('POST creates the item', async () => {
     let res = await request(app)
       .post('/api/v1/levels')
       .set('Accept', 'application/json')
@@ -42,10 +40,9 @@ describe('CRUD TESTS FOR /api/v1/levels', function () {
 
     // Save the ID for later
     id = res.body.id
-    done()
   })
 
-  it('GET should now include the item', async (done) => {
+  it('GET should now include the item', async () => {
     let res = await request(app)
       .get('/api/v1/levels')
       .set('Accept', 'application/json')
@@ -54,10 +51,9 @@ describe('CRUD TESTS FOR /api/v1/levels', function () {
     expect(res.body).toEqual(
       expect.arrayContaining([expect.objectContaining(payload)])
     )
-    done()
   })
 
-  it('GET by ID should return item', async (done) => {
+  it('GET by ID should return item', async () => {
     let res = await request(app)
       .get(`/api/v1/levels/${id}`)
       .set('Accept', 'application/json')
@@ -65,10 +61,9 @@ describe('CRUD TESTS FOR /api/v1/levels', function () {
     expect(res.status).toBe(200)
     expect(res.body).toEqual(expect.objectContaining(payload))
     itemById = res.body
-    done()
   })
 
-  it('GET by NAME should return the same item', async (done) => {
+  it('GET by NAME should return the same item', async () => {
     let res = await request(app)
       .get(`/api/v1/levels/name/${payload.name}`)
       .set('Accept', 'application/json')
@@ -77,10 +72,9 @@ describe('CRUD TESTS FOR /api/v1/levels', function () {
     expect(res.body).toEqual(expect.objectContaining(payload))
     itemByName = res.body
     expect(itemByName).toEqual(itemById)
-    done()
   })
 
-  it('PUT by ID to change the description', async (done) => {
+  it('PUT by ID to change the description', async () => {
     updatedPayload = { ...payload, description: updatedDescription }
 
     expect(payload).not.toEqual(updatedPayload)
@@ -93,35 +87,31 @@ describe('CRUD TESTS FOR /api/v1/levels', function () {
       .expect(200)
 
     expect(res.status).toBe(200)
-    done()
   })
 
-  it('GET by ID should return ***UPDATED*** item', async (done) => {
+  it('GET by ID should return ***UPDATED*** item', async () => {
     let res = await request(app)
       .get(`/api/v1/levels/${id}`)
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
     expect(res.status).toBe(200)
     expect(res.body).toEqual(expect.objectContaining(updatedPayload))
-    done()
   })
 
-  it('DELETE by ID should succeed', async (done) => {
+  it('DELETE by ID should succeed', async () => {
     let res = await request(app)
       .delete(`/api/v1/levels/${id}`)
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
     expect(res.status).toBe(200)
-    done()
   })
 
-  it('GET by ID should NOT find an item', async (done) => {
+  it('GET by ID should NOT find an item', async () => {
     let res = await request(app)
       .get(`/api/v1/levels/${id}`)
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
     expect(res.status).toBe(404)
     expect(res.body).toEqual({ error: 'Not Found' })
-    done()
   })
 })

--- a/server/routes/officials.test.js
+++ b/server/routes/officials.test.js
@@ -10,12 +10,11 @@ describe('CRUD TESTS FOR /api/v1/officials', function () {
   let id
   let updatedPayload = { ...payload, title: updatedTitle }
 
-  it('Make sure the random titles do not match', async (done) => {
+  it('Make sure the random titles do not match', async () => {
     expect(payload.title).not.toEqual(updatedTitle)
-    done()
   })
 
-  it('GET should not have the item.', async (done) => {
+  it('GET should not have the item.', async () => {
     let res = await request(app)
       .get('/api/v1/officials')
       .set('Accept', 'application/json')
@@ -25,10 +24,9 @@ describe('CRUD TESTS FOR /api/v1/officials', function () {
       // NOT!!!
       expect.arrayContaining([expect.objectContaining(payload)])
     )
-    done()
   })
 
-  it('POST creates the item', async (done) => {
+  it('POST creates the item', async () => {
     let res = await request(app)
       .post('/api/v1/officials')
       .set('Accept', 'application/json')
@@ -40,10 +38,9 @@ describe('CRUD TESTS FOR /api/v1/officials', function () {
 
     // Save the ID for later
     id = res.body.id
-    done()
   })
 
-  it('GET should now include the item', async (done) => {
+  it('GET should now include the item', async () => {
     let res = await request(app)
       .get('/api/v1/officials')
       .set('Accept', 'application/json')
@@ -52,10 +49,9 @@ describe('CRUD TESTS FOR /api/v1/officials', function () {
     expect(res.body).toEqual(
       expect.arrayContaining([expect.objectContaining(payload)])
     )
-    done()
   })
 
-  it('GET by ID should return item', async (done) => {
+  it('GET by ID should return item', async () => {
     let res = await request(app)
       .get(`/api/v1/officials/${id}`)
       .set('Accept', 'application/json')
@@ -63,10 +59,9 @@ describe('CRUD TESTS FOR /api/v1/officials', function () {
     expect(res.status).toBe(200)
     expect(res.body).toEqual(expect.objectContaining(payload))
     itemById = res.body
-    done()
   })
 
-  it('PUT by ID to change the title', async (done) => {
+  it('PUT by ID to change the title', async () => {
     updatedPayload = { ...payload, title: updatedTitle }
 
     expect(payload).not.toEqual(updatedPayload)
@@ -79,35 +74,31 @@ describe('CRUD TESTS FOR /api/v1/officials', function () {
       .expect(200)
 
     expect(res.status).toBe(200)
-    done()
   })
 
-  it('GET by ID should return ***UPDATED*** item', async (done) => {
+  it('GET by ID should return ***UPDATED*** item', async () => {
     let res = await request(app)
       .get(`/api/v1/officials/${id}`)
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
     expect(res.status).toBe(200)
     expect(res.body).toEqual(expect.objectContaining(updatedPayload))
-    done()
   })
 
-  it('DELETE by ID should succeed', async (done) => {
+  it('DELETE by ID should succeed', async () => {
     let res = await request(app)
       .delete(`/api/v1/officials/${id}`)
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
     expect(res.status).toBe(200)
-    done()
   })
 
-  it('GET by ID should NOT find an item', async (done) => {
+  it('GET by ID should NOT find an item', async () => {
     let res = await request(app)
       .get(`/api/v1/officials/${id}`)
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
     expect(res.status).toBe(404)
     expect(res.body).toEqual({ error: 'Not Found' })
-    done()
   })
 })

--- a/server/routes/publications.test.js
+++ b/server/routes/publications.test.js
@@ -11,12 +11,11 @@ describe('CRUD TESTS FOR /api/v1/publications', function () {
   let id
   let updatedPayload = { ...payload, description: updatedDescription }
 
-  it('Make sure the random descriptions do not match', async (done) => {
+  it('Make sure the random descriptions do not match', async () => {
     expect(payload.description).not.toEqual(updatedDescription)
-    done()
   })
 
-  it('GET should not have the item.', async (done) => {
+  it('GET should not have the item.', async () => {
     let res = await request(app)
       .get('/api/v1/publications')
       .set('Accept', 'application/json')
@@ -26,10 +25,9 @@ describe('CRUD TESTS FOR /api/v1/publications', function () {
       // NOT!!!
       expect.arrayContaining([expect.objectContaining(payload)])
     )
-    done()
   })
 
-  it('POST creates the item', async (done) => {
+  it('POST creates the item', async () => {
     let res = await request(app)
       .post('/api/v1/publications')
       .set('Accept', 'application/json')
@@ -41,10 +39,9 @@ describe('CRUD TESTS FOR /api/v1/publications', function () {
 
     // Save the ID for later
     id = res.body.id
-    done()
   })
 
-  it('GET should now include the item', async (done) => {
+  it('GET should now include the item', async () => {
     let res = await request(app)
       .get('/api/v1/publications')
       .set('Accept', 'application/json')
@@ -53,10 +50,9 @@ describe('CRUD TESTS FOR /api/v1/publications', function () {
     expect(res.body).toEqual(
       expect.arrayContaining([expect.objectContaining(payload)])
     )
-    done()
   })
 
-  it('GET by ID should return item', async (done) => {
+  it('GET by ID should return item', async () => {
     let res = await request(app)
       .get(`/api/v1/publications/${id}`)
       .set('Accept', 'application/json')
@@ -64,10 +60,9 @@ describe('CRUD TESTS FOR /api/v1/publications', function () {
     expect(res.status).toBe(200)
     expect(res.body).toEqual(expect.objectContaining(payload))
     itemById = res.body
-    done()
   })
 
-  it('PUT by ID to change the description', async (done) => {
+  it('PUT by ID to change the description', async () => {
     updatedPayload = { ...payload, description: updatedDescription }
 
     expect(payload).not.toEqual(updatedPayload)
@@ -80,35 +75,31 @@ describe('CRUD TESTS FOR /api/v1/publications', function () {
       .expect(200)
 
     expect(res.status).toBe(200)
-    done()
   })
 
-  it('GET by ID should return ***UPDATED*** item', async (done) => {
+  it('GET by ID should return ***UPDATED*** item', async () => {
     let res = await request(app)
       .get(`/api/v1/publications/${id}`)
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
     expect(res.status).toBe(200)
     expect(res.body).toEqual(expect.objectContaining(updatedPayload))
-    done()
   })
 
-  it('DELETE by ID should succeed', async (done) => {
+  it('DELETE by ID should succeed', async () => {
     let res = await request(app)
       .delete(`/api/v1/publications/${id}`)
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
     expect(res.status).toBe(200)
-    done()
   })
 
-  it('GET by ID should NOT find an item', async (done) => {
+  it('GET by ID should NOT find an item', async () => {
     let res = await request(app)
       .get(`/api/v1/publications/${id}`)
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
     expect(res.status).toBe(404)
     expect(res.body).toEqual({ error: 'Not Found' })
-    done()
   })
 })

--- a/server/routes/video_testimonials.test.js
+++ b/server/routes/video_testimonials.test.js
@@ -12,12 +12,11 @@ describe('CRUD TESTS FOR /api/v1/videoTestimonials', function () {
   let itemById
   let updatedPayload = { ...payload, subject: updatedSubject }
 
-  it('Make sure the random subjects do not match', async (done) => {
+  it('Make sure the random subjects do not match', async () => {
     expect(payload.subject).not.toEqual(updatedSubject)
-    done()
   })
 
-  it('GET should not have the item.', async (done) => {
+  it('GET should not have the item.', async () => {
     let res = await request(app)
       .get('/api/v1/videoTestimonials')
       .set('Accept', 'application/json')
@@ -27,10 +26,9 @@ describe('CRUD TESTS FOR /api/v1/videoTestimonials', function () {
       // NOT!!!
       expect.arrayContaining([expect.objectContaining(payload)])
     )
-    done()
   })
 
-  it('POST creates the item', async (done) => {
+  it('POST creates the item', async () => {
     let res = await request(app)
       .post('/api/v1/videoTestimonials')
       .set('Accept', 'application/json')
@@ -42,10 +40,9 @@ describe('CRUD TESTS FOR /api/v1/videoTestimonials', function () {
 
     // Save the ID for later
     id = res.body.id
-    done()
   })
 
-  it('GET should now include the item', async (done) => {
+  it('GET should now include the item', async () => {
     let res = await request(app)
       .get('/api/v1/videoTestimonials')
       .set('Accept', 'application/json')
@@ -54,10 +51,9 @@ describe('CRUD TESTS FOR /api/v1/videoTestimonials', function () {
     expect(res.body).toEqual(
       expect.arrayContaining([expect.objectContaining(payload)])
     )
-    done()
   })
 
-  it('GET by ID should return item', async (done) => {
+  it('GET by ID should return item', async () => {
     let res = await request(app)
       .get(`/api/v1/videoTestimonials/${id}`)
       .set('Accept', 'application/json')
@@ -65,10 +61,9 @@ describe('CRUD TESTS FOR /api/v1/videoTestimonials', function () {
     expect(res.status).toBe(200)
     expect(res.body).toEqual(expect.objectContaining(payload))
     itemById = res.body
-    done()
   })
 
-  it('PUT by ID to change the subject', async (done) => {
+  it('PUT by ID to change the subject', async () => {
     updatedPayload = { ...payload, subject: updatedSubject }
 
     expect(payload).not.toEqual(updatedPayload)
@@ -81,35 +76,31 @@ describe('CRUD TESTS FOR /api/v1/videoTestimonials', function () {
       .expect(200)
 
     expect(res.status).toBe(200)
-    done()
   })
 
-  it('GET by ID should return ***UPDATED*** item', async (done) => {
+  it('GET by ID should return ***UPDATED*** item', async () => {
     let res = await request(app)
       .get(`/api/v1/videoTestimonials/${id}`)
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
     expect(res.status).toBe(200)
     expect(res.body).toEqual(expect.objectContaining(updatedPayload))
-    done()
   })
 
-  it('DELETE by ID should succeed', async (done) => {
+  it('DELETE by ID should succeed', async () => {
     let res = await request(app)
       .delete(`/api/v1/videoTestimonials/${id}`)
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
     expect(res.status).toBe(200)
-    done()
   })
 
-  it('GET by ID should NOT find an item', async (done) => {
+  it('GET by ID should NOT find an item', async () => {
     let res = await request(app)
       .get(`/api/v1/videoTestimonials/${id}`)
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
     expect(res.status).toBe(404)
     expect(res.body).toEqual({ error: 'Not Found' })
-    done()
   })
 })


### PR DESCRIPTION
Signed-off-by: Ed Snodgrass <snodgrass.ed@gmail.com>

Contributes to #182 
## What did you do?
removed the done() callbacks from the server/route tests

## Why did you do it?
Linting checks were reporting issues

## How have you tested it?
Ran all the tests.

## Were docs updated if needed?

- [ ] No
- [ ] Yes
- [x] N/A

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new console logs
- [ ] Fixes entire issue
- [x] Partial fix for issue