### PR TITLE
refactor(client): replace text with internationalizing formatter calls. close #242

### DIFF
--- a/client/src/PolicyNotice.js
+++ b/client/src/PolicyNotice.js
@@ -1,7 +1,9 @@
 import React from 'react'
 import { messages } from '../nls/nlsUtility'
+import { injectIntl } from 'react-intl'
+import PropTypes from 'prop-types'
 
-const PolicyNotice = () => {
+const PolicyNotice = ({ intl }) => {
   return (
     <div data-testid={'policyNotice'}>
       {intl.formatMessage(messages.policyNotice)}
@@ -9,4 +11,8 @@ const PolicyNotice = () => {
   )
 }
 
-export default PolicyNotice
+PolicyNotice.propTypes = {
+  intl: PropTypes.any.isRequired,
+}
+
+export default injectIntl(PolicyNotice)

--- a/client/src/PolicyNotice.js
+++ b/client/src/PolicyNotice.js
@@ -1,7 +1,12 @@
 import React from 'react'
+import { messages } from '../nls/nlsUtility'
 
 const PolicyNotice = () => {
-  return <div data-testid={'policyNotice'}>Policy Notice</div>
+  return (
+    <div data-testid={'policyNotice'}>
+      {intl.formatMessage(messages.policyNotice)}
+    </div>
+  )
 }
 
 export default PolicyNotice

--- a/client/src/nls/messages/en/messages.js
+++ b/client/src/nls/messages/en/messages.js
@@ -47,6 +47,15 @@ const messages = {
   seeTestimonials: 'See policy testimonials',
   //Sentiment
   communitySentiment: 'COMMUNITY SENTIMENT',
+  // RecordRoute
+  fullDetail: 'Full Detail',
+  share: 'Share',
+  cancel: 'Cancel',
+  audio: 'Audio Only',
+  noPolicyFound: 'No policy found',
+  // PolicyRoute
+  cannotLoadPolicy: 'Cannot load policy',
+  loading: 'Loading...',
 }
 
 export default messages

--- a/client/src/nls/messages/en/messages.js
+++ b/client/src/nls/messages/en/messages.js
@@ -24,6 +24,7 @@ const messages = {
   privacyRefresh: 'Please refresh this page and accept the privacy statement.',
   //PolicyTable
   noPolicies: 'No Policies Available.',
+  policies: 'POLICIES',
   // PolicyNotice
   policyNotice: 'Policy Notice',
   //Filter
@@ -56,6 +57,7 @@ const messages = {
   // PolicyRoute
   cannotLoadPolicy: 'Cannot load policy',
   loading: 'Loading...',
+  blur: 'Blur',
 }
 
 export default messages

--- a/client/src/nls/messages/en/messages.js
+++ b/client/src/nls/messages/en/messages.js
@@ -24,6 +24,8 @@ const messages = {
   privacyRefresh: 'Please refresh this page and accept the privacy statement.',
   //PolicyTable
   noPolicies: 'No Policies Available.',
+  // PolicyNotice
+  policyNotice: 'Policy Notice',
   //Filter
   filterBy: 'Filter by:',
   //DetailsAccordion

--- a/client/src/policyRoute/PolicyRoute.js
+++ b/client/src/policyRoute/PolicyRoute.js
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
 import { fetchCurrentPolicy } from '../store/policy.duck'
 import PolicyDetail from '../policyDetail/PolicyDetail'
+import { messages } from '../nls/nlsUtility'
 
 const PolicyRoute = () => {
   const { policyId } = useParams()
@@ -25,11 +26,23 @@ const PolicyRoute = () => {
       </h2>
     )
   } else if (status === 'pending') {
-    return <h2 data-testid={'loadingPolicy'}>Loading...</h2>
+    return (
+      <h2 data-testid={'loadingPolicy'}>
+        {intl.formatMessage(messages.loading)}
+      </h2>
+    )
   } else if (status === 'error') {
-    return <h2 data-testid={'cannotLoadPolicy'}>Cannot load policy</h2>
+    return (
+      <h2 data-testid={'cannotLoadPolicy'}>
+        {intl.formatMessage(messages.cannotLoadPolicy)}
+      </h2>
+    )
   }
-  return <h2 data-testid={'emptyPolicy'}>No policy found</h2>
+  return (
+    <h2 data-testid={'emptyPolicy'}>
+      {intl.formatMessage(messages.noPolicyFound)}
+    </h2>
+  )
 }
 
 export default PolicyRoute

--- a/client/src/policyRoute/PolicyRoute.js
+++ b/client/src/policyRoute/PolicyRoute.js
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { fetchCurrentPolicy } from '../store/policy.duck'
 import PolicyDetail from '../policyDetail/PolicyDetail'
 import { messages } from '../nls/nlsUtility'
+import { injectIntl } from 'react-intl'
 
 const PolicyRoute = () => {
   const { policyId } = useParams()
@@ -45,4 +46,8 @@ const PolicyRoute = () => {
   )
 }
 
-export default PolicyRoute
+PolicyRoute.propTypes = {
+  intl: PropTypes.any.isRequired,
+}
+
+export default injectIntl(PolicyRoute)

--- a/client/src/policyRoute/PolicyRoute.js
+++ b/client/src/policyRoute/PolicyRoute.js
@@ -7,7 +7,7 @@ import { messages } from '../nls/nlsUtility'
 import { injectIntl } from 'react-intl'
 import PropTypes from 'prop-types'
 
-const PolicyRoute = () => {
+const PolicyRoute = ({ intl }) => {
   const { policyId } = useParams()
   const dispatch = useDispatch()
   const { currentPolicy, status } = useSelector(({ policy }) => policy)

--- a/client/src/policyRoute/PolicyRoute.js
+++ b/client/src/policyRoute/PolicyRoute.js
@@ -5,6 +5,7 @@ import { fetchCurrentPolicy } from '../store/policy.duck'
 import PolicyDetail from '../policyDetail/PolicyDetail'
 import { messages } from '../nls/nlsUtility'
 import { injectIntl } from 'react-intl'
+import PropTypes from 'prop-types'
 
 const PolicyRoute = () => {
   const { policyId } = useParams()

--- a/client/src/policyTable/PolicyTable.js
+++ b/client/src/policyTable/PolicyTable.js
@@ -38,7 +38,9 @@ const PolicyTable = ({ policies, intl }) => {
     <div data-testid={'policyTable'}>
       <Grid className={'policy-table'}>
         <Row className={'policy-title-row'}>
-          <Column>{`POLICIES: (${policies.length})`}</Column>
+          <Column>{`${intl.formatMessage(messages.policies)}: (${
+            policies.length
+          })`}</Column>
         </Row>
         {policies.map(renderItem)}
       </Grid>

--- a/client/src/recordRoute/RecordRoute.js
+++ b/client/src/recordRoute/RecordRoute.js
@@ -157,7 +157,9 @@ const RecordRoute = ({ intl }) => {
                 <div>{intl.formatMessage(messages.fullDetail)}</div>
               </Column>
               <Column className={'col-2'}>
-                <div className="btn-blur">Blur</div>
+                <div className="btn-blur">
+                  {intl.formatMessage(messages.blur)}
+                </div>
               </Column>
               <Column className={'col-3'}>
                 <div>{intl.formatMessage(messages.audio)}</div>

--- a/client/src/recordRoute/RecordRoute.js
+++ b/client/src/recordRoute/RecordRoute.js
@@ -5,6 +5,9 @@ import StopFilledAlt32 from '@carbon/icons-react/lib/stop--filled--alt/32'
 import RecordingFilledAlt32 from '@carbon/icons-react/lib/recording--filled--alt/32'
 import Webcam from 'react-webcam'
 import RecordRTC from 'recordrtc'
+import { messages } from '../nls/nlsUtility'
+import { injectIntl } from 'react-intl'
+import PropTypes from 'prop-types'
 
 import './RecordRoute.scss'
 
@@ -18,7 +21,7 @@ const mediaConstraints = {
   audio: true,
 }
 
-const RecordRoute = () => {
+const RecordRoute = ({ intl }) => {
   const { policyId } = useParams()
 
   const webcamRef = useRef(null)
@@ -120,14 +123,20 @@ const RecordRoute = () => {
   )
 
   if (!policyId) {
-    return <h2 data-testid={'noPolicyFound'}>No policy found</h2>
+    return (
+      <h2 data-testid={'noPolicyFound'}>
+        {intl.formatMessage(messages.noPolicyFound)}
+      </h2>
+    )
   }
 
   return (
     <div className="bx--grid bx--grid--default bx--grid--no-gutter tell-me-content">
       <div className="bx--row">
         <div className="bx--col r1-col">
-          <div className="page-title">Tell My Story</div>
+          <div className="page-title">
+            {intl.formatMessage(messages.tellStory)}
+          </div>
         </div>
       </div>
       <div className="bx--row">
@@ -145,13 +154,13 @@ const RecordRoute = () => {
           <Grid className={'video-control-panel'}>
             <Row className={'grid-row'}>
               <Column className={'col-1'}>
-                <div>Full Detail</div>
+                <div>{intl.formatMessage(messages.fullDetail)}</div>
               </Column>
               <Column className={'col-2'}>
                 <div className="btn-blur">Blur</div>
               </Column>
               <Column className={'col-3'}>
-                <div>Audio Only</div>
+                <div>{intl.formatMessage(messages.audio)}</div>
               </Column>
             </Row>
             <Row className={'grid-row'}>
@@ -174,14 +183,17 @@ const RecordRoute = () => {
       </div>
       <div className="bx--row">
         <div className="bx--col r4-col bx--btn--secondary">
-          <div className="btn">Cancel</div>
+          <div className="btn">{intl.formatMessage(messages.cancel)}</div>
         </div>
         <div className="bx--col r4-col bx--btn--primary">
-          <div className="btn">Share</div>
+          <div className="btn">{intl.formatMessage(messages.share)}</div>
         </div>
       </div>
     </div>
   )
 }
+RecordRoute.propTypes = {
+  intl: PropTypes.any.isRequired,
+}
 
-export default RecordRoute
+export default injectIntl(RecordRoute)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "Truth-Loop",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION


Contributes to #242 

## What did you do?
Replace plain text with internationalizing formatter calls to expedite translation

## Why did you do it?
To enable users to view text in their preferred (available) language

## How have you tested it?
No

## Were docs updated if needed?
- [x] No
- [ ] Yes
- [ ] N/A

#### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new console logs
- [x] Fixes entire issue
- [ ] Partial fix for issue