### PR TITLE
removed 'http://localhost:5000' from api-docs link

### DIFF
--- a/server/admin/src/sidemenu/SideNav.js
+++ b/server/admin/src/sidemenu/SideNav.js
@@ -49,7 +49,7 @@ const SideNav = ({ open, handleClose, handleOpen }) => {
     { label: 'Officials', link: '/officials' },
     { label: 'Publications', link: '/publications' },
     { label: 'Video Testimonials', link: '/videoTestimonials' },
-    { label: 'REST API Docs', link: 'http://localhost:5000/api-docs' },
+    { label: 'REST API Docs', link: '/api-docs' },
   ]
   return (
     <nav data-testid="navbar">


### PR DESCRIPTION
Signed-off-by: ugochukwu avoaja <karlthegoo@hotmail.com>

Contributes to #265  (add issue number here. i.e. `#302`)

## What did you do?
Removed 'http://localhost:5000' from '/api-docs' links
## Why did you do it?
So that the link can work when the app is hosted on other localhost ports
## How have you tested it?
No test required
## Were docs updated if needed?

- [x] No
- [ ] Yes
- [ ] N/A

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new console logs
- [x] Fixes entire issue
- [ ] Partial fix for issue